### PR TITLE
Fix typos

### DIFF
--- a/4-cross-chain/2-upward.md
+++ b/4-cross-chain/2-upward.md
@@ -6,8 +6,8 @@ any account with DOTs on the parachain regardless of whether it was the account 
 
 ## Sending Tokens Up
 
-To send tokens from Alice's account on a Parachain to Ferdie's account on the Relay Chain, you submit a single
-transaction on the Parachain. Return to the Apps instance that is connected to the relay chain, navigate to the
+To send tokens from Alice's account on a parachain to Ferdie's account on the Relay Chain, you submit a single
+transaction on the parachain. Go to the Apps instance that is connected to the parachain, navigate to the
 Parachains tab, and click the lonely "Transfer to chain" button.
 
 Fill in the details as you desire and submit the transaction. Take careful note of the toggle switch in the bottom

--- a/5-develop/1-template-overview.md
+++ b/5-develop/1-template-overview.md
@@ -1,6 +1,6 @@
 # Parachain Collator Template
 
-Substrate developers are familiar with the
+Substrate developers who are familiar with the
 [Substrate Node Template](https://github.com/substrate-developer-hub/substrate-node-template) will find the parachain
 template familiar. They have the same general structure featuring `node`, `runtime`, and `pallets` directories. Their
 runtimes are similar and feature many of the same pallets. And apart from a few new traits, the pallets themselves are
@@ -34,7 +34,7 @@ from foreign chains, you should either use this pallet or use its code as inspir
 ### `register_validate_block!` Macro
 
 Each parachain must supply a `validate_block` function, expressed as a wasm blob, to the relay chain when registering.
-The node template does not provide this function, but the parachain template provides does. Thanks to cumulus, creating
+The node template does not provide this function, but the parachain template does. Thanks to cumulus, creating
 this function for a Substrate runtime is as simple as adding one line of code at the bottom of your runtime:
 
 ```rust


### PR DESCRIPTION
Mainly fixes the instructions for "Sending Tokens Up": this operation
has to be initiated from the parachain, not from the relay chain.