### PR TITLE
Add docs on registering a parachain

### DIFF
--- a/6-register/1-register.md
+++ b/6-register/1-register.md
@@ -1,0 +1,40 @@
+# Register a Rococo Parachain
+
+Rococo is Parity's official test network for Cumulus-based parachains. The purpose of this document
+is to guide Cumulus parachain developers through the steps needed to register their parachain with
+the Rococo test network.
+
+## Write Your Parachain
+
+Follow the steps in the previous chapter to develop your parachain. In particular, refer to the
+[Parachain Template Overview](../5-develop/1-template-overview) and
+[Template Pallet](../5-develop/3-template-pallet) sections.
+
+## Test Your Parachain
+
+Follow the steps in the previous section to test your parachain. In particular, refer to the
+[Sending Messages](../5-develop/4-sending-messages) and
+[Receiving Messages](../5-develop/5-receiving-messages) sections.
+
+## Request ROC Tokens
+
+The symbol for the Rococo test network's native currency is ROC; you will need some ROC in order
+to register your Rococo parachain. Please use
+[our Rococo Element chat room](https://app.element.io/#/room/!WuksvCDImqYSxvNmua:matrix.parity.io?via=matrix.org)
+to request ROC tokens.
+
+## Launch Rococo Validators
+
+In order to register a parachain with the Rococo test network, it is necessary to support the
+central Rococo relay chain by running two Rococo validator nodes. Refer to the first chapter to
+learn how to [build a Rococo validator node](../1-prep/1-compiling#building-a-relay-chain-node) and
+the second chapter to learn how to [launch the node you just built](../2-relay-chain/2-launch). Once
+you have launched your nodes, you will need to rotate your session keys and make note of the new
+keys.
+
+## Request Parachain Registration
+
+Use
+[the Propose Parachain pallet](https://github.com/paritytech/polkadot/blob/rococo-branch/runtime/rococo/src/propose_parachain.rs)
+to request parachain registration and wait for us to approve it.
+

--- a/6-register/1-register.md
+++ b/6-register/1-register.md
@@ -1,40 +1,37 @@
 # Register a Rococo Parachain
 
-Rococo is Parity's official test network for Cumulus-based parachains. The purpose of this document
-is to guide Cumulus parachain developers through the steps needed to register their parachain with
-the Rococo test network.
+Rococo is Parity's official test network for Cumulus-based parachains. The purpose of this document is to guide Cumulus
+parachain developers through the steps needed to register their parachain with the Rococo test network.
 
 ## Write Your Parachain
 
 Follow the steps in the previous chapter to develop your parachain. In particular, refer to the
-[Parachain Template Overview](../5-develop/1-template-overview) and
-[Template Pallet](../5-develop/3-template-pallet) sections.
+[Parachain Template Overview](../5-develop/1-template-overview.md) and
+[Template Pallet](../5-develop/3-template-pallet.md) sections.
 
 ## Test Your Parachain
 
 Follow the steps in the previous section to test your parachain. In particular, refer to the
-[Sending Messages](../5-develop/4-sending-messages) and
-[Receiving Messages](../5-develop/5-receiving-messages) sections.
+[Sending Messages](../5-develop/4-sending-messages.md) and [Receiving Messages](../5-develop/5-receiving-messages.md)
+sections.
 
 ## Request ROC Tokens
 
-The symbol for the Rococo test network's native currency is ROC; you will need some ROC in order
-to register your Rococo parachain. Please use
-[our Rococo Element chat room](https://app.element.io/#/room/!WuksvCDImqYSxvNmua:matrix.parity.io?via=matrix.org)
-to request ROC tokens.
+The symbol for the Rococo test network's native currency is ROC; you will need some ROC in order to register your Rococo
+parachain. Please use
+[our Rococo Element chat room](https://app.element.io/#/room/!WuksvCDImqYSxvNmua:matrix.parity.io?via=matrix.org) to
+request ROC tokens.
 
 ## Launch Rococo Validators
 
-In order to register a parachain with the Rococo test network, it is necessary to support the
-central Rococo relay chain by running two Rococo validator nodes. Refer to the first chapter to
-learn how to [build a Rococo validator node](../1-prep/1-compiling#building-a-relay-chain-node) and
-the second chapter to learn how to [launch the node you just built](../2-relay-chain/2-launch). Once
-you have launched your nodes, you will need to rotate your session keys and make note of the new
-keys.
+In order to register a parachain with the Rococo test network, it is necessary to support the central Rococo relay chain
+by running two Rococo validator nodes. Refer to the first chapter to learn how to
+[build a Rococo validator node](../1-prep/1-compiling#building-a-relay-chain-node.md) and the second chapter to learn
+how to [launch the node you just built](../2-relay-chain/2-launch.md). Once you have launched your nodes, you will need
+to rotate your session keys and make note of the new keys.
 
 ## Request Parachain Registration
 
 Use
 [the Propose Parachain pallet](https://github.com/paritytech/polkadot/blob/rococo-branch/runtime/rococo/src/propose_parachain.rs)
 to request parachain registration and wait for us to approve it.
-

--- a/6-register/1-register.md
+++ b/6-register/1-register.md
@@ -31,7 +31,7 @@ by running at least two Rococo validator nodes. Refer to the first chapter to le
 nodes, run the following command:
 
 ```shell
-./target/release/polkadot --chain rococo --validator
+./target/release/polkadot --chain rococo --validator --wasm-execution=Compiled
 ```
 
 You will need to generate session keys for each of your Rococo validator nodes. To generate keys for a node, use the

--- a/6-register/1-register.md
+++ b/6-register/1-register.md
@@ -19,13 +19,13 @@ sections.
 
 The symbol for the Rococo test network's native currency is ROC; you will need some ROC in order to register your Rococo
 parachain. Please use
-[our #Rococo Element chat room](https://app.element.io/#/room/!WuksvCDImqYSxvNmua:matrix.parity.io?via=matrix.org) to
+our [#Rococo Element chat room](https://app.element.io/#/room/!WuksvCDImqYSxvNmua:matrix.parity.io?via=matrix.org) to
 request ROC tokens.
 
 ## Launch Rococo Validators
 
-In order to register a parachain with the Rococo test network, it is necessary to support the central Rococo relay chain
-by running two Rococo validator nodes. Refer to the first chapter to learn how to
+In order to register a parachain with the Rococo test network, we require you to support the central Rococo relay chain
+by running at least two Rococo validator nodes. Refer to the first chapter to learn how to
 [build a Rococo validator node](../1-prep/1-compiling.md#building-a-relay-chain-node) and the second chapter to learn
 how to [launch the node you just built](../2-relay-chain/2-launch.md). Once you have launched your nodes, you will need
 to rotate your session keys and make note of the new keys.

--- a/6-register/1-register.md
+++ b/6-register/1-register.md
@@ -19,14 +19,14 @@ sections.
 
 The symbol for the Rococo test network's native currency is ROC; you will need some ROC in order to register your Rococo
 parachain. Please use
-[our Rococo Element chat room](https://app.element.io/#/room/!WuksvCDImqYSxvNmua:matrix.parity.io?via=matrix.org) to
+[our #Rococo Element chat room](https://app.element.io/#/room/!WuksvCDImqYSxvNmua:matrix.parity.io?via=matrix.org) to
 request ROC tokens.
 
 ## Launch Rococo Validators
 
 In order to register a parachain with the Rococo test network, it is necessary to support the central Rococo relay chain
 by running two Rococo validator nodes. Refer to the first chapter to learn how to
-[build a Rococo validator node](../1-prep/1-compiling#building-a-relay-chain-node.md) and the second chapter to learn
+[build a Rococo validator node](../1-prep/1-compiling.md#building-a-relay-chain-node) and the second chapter to learn
 how to [launch the node you just built](../2-relay-chain/2-launch.md). Once you have launched your nodes, you will need
 to rotate your session keys and make note of the new keys.
 

--- a/6-register/1-register.md
+++ b/6-register/1-register.md
@@ -1,19 +1,20 @@
 # Register a Rococo Parachain
 
 Rococo is Parity's official test network for Cumulus-based parachains. The purpose of this document is to guide Cumulus
-parachain developers through the steps needed to register their parachain with the Rococo test network.
+parachain developers through the steps needed to register their parachain with the Rococo test network. This page is an
+_addendum_ to the main workshop. Before you attempt to register your parachain on a public testnet like Rococo, we
+expect that you have gone through the entire workshop and been in contact with us through our
+[#Rococo Element chat room](https://app.element.io/#/room/!WuksvCDImqYSxvNmua:matrix.parity.io?via=matrix.org)
 
 ## Write Your Parachain
 
-Follow the steps in the previous chapter to develop your parachain. In particular, refer to the
-[Parachain Template Overview](../5-develop/1-template-overview.md) and
+You covered this material in the [Parachain Template Overview](../5-develop/1-template-overview.md) and
 [Template Pallet](../5-develop/3-template-pallet.md) sections.
 
 ## Test Your Parachain
 
-Follow the steps in the previous section to test your parachain. In particular, refer to the
-[Sending Messages](../5-develop/4-sending-messages.md) and [Receiving Messages](../5-develop/5-receiving-messages.md)
-sections.
+You covered this material in the [Sending Messages](../5-develop/4-sending-messages.md) and
+[Receiving Messages](../5-develop/5-receiving-messages.md) sections.
 
 ## Request ROC Tokens
 
@@ -53,8 +54,8 @@ In [Chapter 3, Section 2](../3-parachains/2-register.md) we used the Sudo pallet
 register a parachain. The actual Rococo relay chain uses
 [the Propose Parachain pallet](https://github.com/paritytech/polkadot/blob/rococo-branch/runtime/rococo/src/propose_parachain.rs)
 to allow parachain developers to request parachain registration. Use the
-[Polkadot JS Apps UI Extrinsics app](https://polkadot.js.org/apps/#/extrinsics) to call the
-`proposeParachain.proposeParachain` dispatchable on the Rococo relay chain and provide the following parameters:
+[Polkadot JS Apps UI Extrinsics app](https://polkadot.js.org/apps/#/extrinsics?rpc=wss://rococo-rpc.polkadot.io) to call
+the `proposeParachain.proposeParachain` dispatchable on the Rococo relay chain and provide the following parameters:
 
 - `para_id`: the ID of your parachain
 - `name`: a hex-encoded name for your parachain

--- a/6-register/1-register.md
+++ b/6-register/1-register.md
@@ -17,8 +17,9 @@ sections.
 
 ## Request ROC Tokens
 
-The symbol for the Rococo test network's native currency is ROC; you will need some ROC in order to register your Rococo
-parachain. Please use our
+The symbol for the Rococo test network's native currency is ROC. You will need some ROC in order to register your Rococo
+parachain. There is a deposit required to register a parachain (currently 1,000 ROC) and you will also need some
+additional ROC in order pay transaction fees. Please use our
 [#Rococo Element chat room](https://app.element.io/#/room/!WuksvCDImqYSxvNmua:matrix.parity.io?via=matrix.org) to
 request ROC tokens.
 
@@ -33,10 +34,34 @@ nodes, run the following command:
 ./target/release/polkadot --chain rococo --validator
 ```
 
-Once you have launched your nodes, you will need to rotate your session keys and make note of the new keys.
+You will need to generate session keys for each of your Rococo validator nodes. To generate keys for a node, use the
+`author.rotateKeys` RPC call. One way to invoke this RPC method is by using `curl`:
+
+```shell
+curl http://<validator address>:<WebSocket port>\
+  -H "Content-Type:application/json;charset=utf-8"\
+  -d '{ "jsonrpc":"2.0", "id":1, "method":"author_rotateKeys" }'
+```
+
+You can also use the [Polkadot JS Apps UI RPC app](https://polkadot.js.org/apps/#/rpc) to invoke the RPC method, just
+make sure you are connected to the correct node. Regardless of how you generate these keys, take note of them and treat
+them with care - you need to provide them when you submit your request for parachain registration.
 
 ## Request Parachain Registration
 
-Use
+In [Chapter 3, Section 2](../3-parachains/2-register.md) we used the Sudo pallet on a development relay chain to
+register a parachain. The actual Rococo relay chain uses
 [the Propose Parachain pallet](https://github.com/paritytech/polkadot/blob/rococo-branch/runtime/rococo/src/propose_parachain.rs)
-to request parachain registration and wait for us to approve it.
+to allow parachain developers to request parachain registration. Use the
+[Polkadot JS Apps UI Extrinsics app](https://polkadot.js.org/apps/#/extrinsics) to call the
+`proposeParachain.proposeParachain` dispatchable and provide the following parameters:
+
+- `para_id`: the ID of your parachain
+- `name`: a hex-encoded name for your parachain
+- `validation_function`: the Wasm runtime for your parachain
+- `initial_head_state`: your parachain's genesis state
+- `validators`: two validators from the previous step
+- `balance`: the constant value `1000`
+
+Let us know when you have submitted this request (use the Element chat room), and we will do our best to get back to you
+within a day or two.

--- a/6-register/1-register.md
+++ b/6-register/1-register.md
@@ -18,17 +18,22 @@ sections.
 ## Request ROC Tokens
 
 The symbol for the Rococo test network's native currency is ROC; you will need some ROC in order to register your Rococo
-parachain. Please use
-our [#Rococo Element chat room](https://app.element.io/#/room/!WuksvCDImqYSxvNmua:matrix.parity.io?via=matrix.org) to
+parachain. Please use our
+[#Rococo Element chat room](https://app.element.io/#/room/!WuksvCDImqYSxvNmua:matrix.parity.io?via=matrix.org) to
 request ROC tokens.
 
 ## Launch Rococo Validators
 
 In order to register a parachain with the Rococo test network, we require you to support the central Rococo relay chain
 by running at least two Rococo validator nodes. Refer to the first chapter to learn how to
-[build a Rococo validator node](../1-prep/1-compiling.md#building-a-relay-chain-node) and the second chapter to learn
-how to [launch the node you just built](../2-relay-chain/2-launch.md). Once you have launched your nodes, you will need
-to rotate your session keys and make note of the new keys.
+[build a Rococo validator node](../1-prep/1-compiling.md#building-a-relay-chain-node). To launch your Rococo validator
+nodes, run the following command:
+
+```shell
+./target/release/polkadot --chain rococo --validator
+```
+
+Once you have launched your nodes, you will need to rotate your session keys and make note of the new keys.
 
 ## Request Parachain Registration
 

--- a/6-register/1-register.md
+++ b/6-register/1-register.md
@@ -54,7 +54,7 @@ register a parachain. The actual Rococo relay chain uses
 [the Propose Parachain pallet](https://github.com/paritytech/polkadot/blob/rococo-branch/runtime/rococo/src/propose_parachain.rs)
 to allow parachain developers to request parachain registration. Use the
 [Polkadot JS Apps UI Extrinsics app](https://polkadot.js.org/apps/#/extrinsics) to call the
-`proposeParachain.proposeParachain` dispatchable and provide the following parameters:
+`proposeParachain.proposeParachain` dispatchable on the Rococo relay chain and provide the following parameters:
 
 - `para_id`: the ID of your parachain
 - `name`: a hex-encoded name for your parachain

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -22,4 +22,6 @@
   - [Template Pallet](5-develop/3-template-pallet.md)
   - [Sending Messages](5-develop/4-sending-messages.md)
   - [Receiving Messages](5-develop/5-receiving-messages.md)
+- Register a Rococo Parachain
+  - [Register a Rococo Parachain](6-register/1-register.md)
 - [Notepad](embedded-notes.md)

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -22,6 +22,4 @@
   - [Template Pallet](5-develop/3-template-pallet.md)
   - [Sending Messages](5-develop/4-sending-messages.md)
   - [Receiving Messages](5-develop/5-receiving-messages.md)
-- Register a Rococo Parachain
-  - [Register a Rococo Parachain](6-register/1-register.md)
 - [Notepad](embedded-notes.md)


### PR DESCRIPTION
This PR adds a page detailing the process of registering a parachain on the public rococo testnet. The page is not in the workshop's table of contents (ToC ;-)) as the steps should not be followed merely for learning purposes.