### PR TITLE
Link to spec JSON triggers download rather than open

### DIFF
--- a/1-prep/2-chain-spec.md
+++ b/1-prep/2-chain-spec.md
@@ -14,12 +14,12 @@ This workshop contains three chain-spec files that you can use without modificat
 
 <!-- for some reason these links can't be markdown. See https://github.com/substrate-developer-hub/cumulus-workshop/issues/16 -->
 
-- <a href="specs/rococo-local.json">specs/rococo-local.json</a>: A two-validator relay chain with Alice and Bob as authorities.
+- <a href="specs/rococo-local.json" download>specs/rococo-local.json</a>: A two-validator relay chain with Alice and Bob as authorities.
   Useful for registering a single parachain. This is a direct export of the `rococo-local` spec that is included in
   polkadot.
-- <a href="specs/rococo-3.json">specs/rococo-3.json</a>: A three-validator relay chain identical to `rococo-local` but with
+- <a href="specs/rococo-3.json" download>specs/rococo-3.json</a>: A three-validator relay chain identical to `rococo-local` but with
   Charlie as a third validator.
-- <a href="specs/rococo-4.json">specs/rococo-4.json</a>. A four-validator relay chain that adds Dave as a fourth validator.
+- <a href="specs/rococo-4.json" download>specs/rococo-4.json</a>. A four-validator relay chain that adds Dave as a fourth validator.
 
 These specs were created according to the steps in the next section. If you would like even more validators, or to
 customize the relay chain in some other way, proceed to the final option.


### PR DESCRIPTION
The links on this page https://substrate.dev/cumulus-workshop/#/1-prep/2-chain-spec